### PR TITLE
Fast Checklists

### DIFF
--- a/src/main/java/ch/cern/eam/wshub/core/services/workorders/entities/WorkOrder.java
+++ b/src/main/java/ch/cern/eam/wshub/core/services/workorders/entities/WorkOrder.java
@@ -190,6 +190,9 @@ public class WorkOrder implements Serializable {
 	@InforField(xpath = "UserDefinedFields")
 	private UserDefinedFields userDefinedFields;
 
+	@Transient
+	private boolean confirmedIncompleteChecklist;
+
 	@Column(name = "EVT_ORIGWO")
 	private String origWO;
 
@@ -616,6 +619,14 @@ public class WorkOrder implements Serializable {
 	public BigDecimal getDowntimeHours() { return downtimeHours; }
 
 	public void setDowntimeHours(BigDecimal downtimeHours) { this.downtimeHours = downtimeHours; }
+
+	public boolean isConfirmedIncompleteChecklist() {
+		return confirmedIncompleteChecklist;
+	}
+
+	public void setConfirmedIncompleteChecklist(boolean confirmedIncompleteChecklist) {
+		this.confirmedIncompleteChecklist = confirmedIncompleteChecklist;
+	}
 
 	@Override
 	public String toString() {

--- a/src/main/java/ch/cern/eam/wshub/core/services/workorders/entities/WorkOrderActivityCheckList.java
+++ b/src/main/java/ch/cern/eam/wshub/core/services/workorders/entities/WorkOrderActivityCheckList.java
@@ -8,6 +8,33 @@ import java.util.Arrays;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 public class WorkOrderActivityCheckList implements Serializable {
+	public static final class CheckListType {
+		public static final String CHECKLIST_ITEM = "01";
+		public static final String QUESTION_YES_NO = "02";
+		public static final String QUALITATIVE = "03";
+		public static final String QUANTITATIVE = "04";
+		public static final String METER_READING = "05";
+		public static final String INSPECTION = "06";
+		public static final String OK_REPAIR_NEEDED = "07";
+		public static final String GOOD_POOR = "08";
+		public static final String OK_ADJUSTED = "09";
+		public static final String OK_ADJUSTED_MEASUREMENT = "10";
+		public static final String NONCONFORMITY_CHECK = "11";
+		public static final String NONCONFORMITY_MEASUREMENT = "12";
+	}
+
+	public static final class ReturnType {
+		public static final String NULL = null;
+		public static final String YES = "YES";
+		public static final String NO = "NO";
+		public static final String OK = "OK";
+		public static final String COMPLETED = "COMPLETED";
+		public static final String GOOD = "GOOD";
+		public static final String POOR = "POOR";
+		public static final String NONCONFORMITY = "NONCONFORMITY";
+		public static final String ADJUSTED = "ADJUSTED";
+		public static final String REPAIRSNEEDED = "REPAIRSNEEDED";
+	}
 
 	/**
 	 * 

--- a/src/main/java/ch/cern/eam/wshub/core/services/workorders/entities/WorkOrderActivityCheckList.java
+++ b/src/main/java/ch/cern/eam/wshub/core/services/workorders/entities/WorkOrderActivityCheckList.java
@@ -3,6 +3,7 @@ package ch.cern.eam.wshub.core.services.workorders.entities;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import java.io.Serializable;
+import java.math.BigDecimal;
 import java.util.Arrays;
 
 @XmlAccessorType(XmlAccessType.FIELD)
@@ -24,6 +25,7 @@ public class WorkOrderActivityCheckList implements Serializable {
 	private String updateCount;
 	private String type;
 	private String result;
+	private BigDecimal numericValue;
 	private String finding;
 	private String notes;
 	private String UOM;
@@ -141,6 +143,14 @@ public class WorkOrderActivityCheckList implements Serializable {
 		this.result = result;
 	}
 
+	public BigDecimal getNumericValue() {
+		return numericValue;
+	}
+
+	public void setNumericValue(BigDecimal numericValue) {
+		this.numericValue = numericValue;
+	}
+
 	public Boolean getFollowUp() {
 		return followUp;
 	}
@@ -216,19 +226,6 @@ public class WorkOrderActivityCheckList implements Serializable {
 		}
 	}
 
-
-	public Double getNumberResult() {
-		if (result != null) {
-			return new Double(result);
-		} else {
-			return null;
-		}
-	}
-
-	public void setNumberResult(Double doubleResult) {
-		result = doubleResult.toString();
-	}
-
 	public boolean isCompleted() {
 		return "COMPLETED".equalsIgnoreCase(result);
 	}
@@ -286,6 +283,7 @@ public class WorkOrderActivityCheckList implements Serializable {
 				", updateCount='" + updateCount + '\'' +
 				", type='" + type + '\'' +
 				", result='" + result + '\'' +
+				", numericValue=" + numericValue +
 				", finding='" + finding + '\'' +
 				", notes='" + notes + '\'' +
 				", UOM='" + UOM + '\'' +

--- a/src/main/java/ch/cern/eam/wshub/core/services/workorders/entities/WorkOrderActivityCheckList.java
+++ b/src/main/java/ch/cern/eam/wshub/core/services/workorders/entities/WorkOrderActivityCheckList.java
@@ -61,6 +61,7 @@ public class WorkOrderActivityCheckList implements Serializable {
 	private Boolean followUp = false;
 	private String followUpWorkOrder;
 	private Boolean requiredToClose = false;
+	private Boolean hideFollowUp;
 
 	private String newCheckListCode;
 	private String newWorkOrderCode;
@@ -200,6 +201,14 @@ public class WorkOrderActivityCheckList implements Serializable {
 
 	public void setRequiredToClose(Boolean requiredToClose) {
 		this.requiredToClose = requiredToClose;
+	}
+
+	public Boolean getHideFollowUp() {
+		return hideFollowUp;
+	}
+
+	public void setHideFollowUp(Boolean hideFollowUp) {
+		this.hideFollowUp = hideFollowUp;
 	}
 
 	//

--- a/src/main/java/ch/cern/eam/wshub/core/services/workorders/impl/ChecklistServiceImpl.java
+++ b/src/main/java/ch/cern/eam/wshub/core/services/workorders/impl/ChecklistServiceImpl.java
@@ -32,8 +32,11 @@ import javax.persistence.EntityManager;
 import javax.xml.ws.Holder;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
 import java.util.logging.Level;
 
 public class ChecklistServiceImpl implements ChecklistService {
@@ -92,6 +95,9 @@ public class ChecklistServiceImpl implements ChecklistService {
 			workOrderActivityCheckListInfor.setFOLLOWUP(tools.getDataTypeTools().encodeBoolean(workOrderActivityCheckList.getFollowUp(), BooleanType.PLUS_MINUS));
 		}
 
+		Function<String, String> getStringBool =
+			key -> String.valueOf(key.equals(workOrderActivityCheckList.getResult()));
+
 		switch (workOrderActivityCheckList.getType()) {
 			case CheckListType.CHECKLIST_ITEM:
 				if ("COMPLETED".equalsIgnoreCase(workOrderActivityCheckList.getResult())) {
@@ -101,9 +107,8 @@ public class ChecklistServiceImpl implements ChecklistService {
 				}
 				break;
 			case CheckListType.QUESTION_YES_NO:
-				workOrderActivityCheckListInfor
-						.setYES(String.valueOf("YES".equals(workOrderActivityCheckList.getResult())));
-				workOrderActivityCheckListInfor.setNO(String.valueOf("NO".equals(workOrderActivityCheckList.getResult())));
+				workOrderActivityCheckListInfor.setYES(getStringBool.apply("YES"));
+				workOrderActivityCheckListInfor.setNO(getStringBool.apply("NO"));
 				break;
 			case CheckListType.QUALITATIVE:
 				if (workOrderActivityCheckList.getFinding() != null) {
@@ -127,6 +132,34 @@ public class ChecklistServiceImpl implements ChecklistService {
 				}
 				workOrderActivityCheckListInfor
 						.setRESULTVALUE(tools.getDataTypeTools().encodeQuantity(encodeBigDecimal(workOrderActivityCheckList.getResult(), ""), "Checklists Value"));
+				break;
+			case CheckListType.OK_REPAIR_NEEDED:
+				workOrderActivityCheckListInfor.setOKFLAG(getStringBool.apply("OK"));
+				workOrderActivityCheckListInfor.setREPAIRSNEEDED(getStringBool.apply("REPAIRSNEEDED"));
+				workOrderActivityCheckListInfor.setRESOLUTIONID(new USERDEFINEDCODEID_Type());
+				workOrderActivityCheckListInfor.getRESOLUTIONID().setUSERDEFINEDCODE(workOrderActivityCheckList.getFinding());
+				break;
+			case CheckListType.GOOD_POOR:
+				workOrderActivityCheckListInfor.setGOOD(getStringBool.apply("GOOD"));
+				workOrderActivityCheckListInfor.setPOOR(getStringBool.apply("POOR"));
+				break;
+			case CheckListType.OK_ADJUSTED_MEASUREMENT:
+				workOrderActivityCheckListInfor
+					.setRESULTVALUE(tools.getDataTypeTools().encodeQuantity(workOrderActivityCheckList.getNumericValue(), "Checklists Value"));
+				// no break here, OK_ADJUSTED_MEASUREMENT is the same as OK_ADJUSTED,
+				// but with a numeric value, so we will set the result to OK/ADJUSTED below
+			case CheckListType.OK_ADJUSTED:
+				workOrderActivityCheckListInfor.setOKFLAG(getStringBool.apply("OK"));
+				workOrderActivityCheckListInfor.setADJUSTED(getStringBool.apply("ADJUSTED"));
+				break;
+			case CheckListType.NONCONFORMITY_MEASUREMENT:
+				workOrderActivityCheckListInfor
+					.setRESULTVALUE(tools.getDataTypeTools().encodeQuantity(workOrderActivityCheckList.getNumericValue(), "Checklists Value"));
+				// no break here, NONCONFORMITY_MEASUREMENT is the same as NONCONFORMITY_CHECK,
+				// but with a numberic value, so we will set the result to OK/NONCONFORMITY below
+			case CheckListType.NONCONFORMITY_CHECK:
+				workOrderActivityCheckListInfor.setOKFLAG(getStringBool.apply("OK"));
+				workOrderActivityCheckListInfor.setNONCONFORMITYFLAG(getStringBool.apply("NONCONFIRMITY"));
 				break;
 		}
 

--- a/src/main/java/ch/cern/eam/wshub/core/services/workorders/impl/ChecklistServiceImpl.java
+++ b/src/main/java/ch/cern/eam/wshub/core/services/workorders/impl/ChecklistServiceImpl.java
@@ -353,7 +353,8 @@ public class ChecklistServiceImpl implements ChecklistService {
 
 		//checklistTemp.setFinalOccurrence(v_result.getString("ack_finaloccurrence"));
 		checklist.setDesc(getCellContent("checklistdescription", row));
-
+		
+		checklist.setHideFollowUp(cellEquals(row, "hidefollowup", "true"));
 		//
 		// VALUES FOR DIFFERENT CHECKLIST TYPES
 		//

--- a/src/main/java/ch/cern/eam/wshub/core/services/workorders/impl/WorkOrderServiceImpl.java
+++ b/src/main/java/ch/cern/eam/wshub/core/services/workorders/impl/WorkOrderServiceImpl.java
@@ -275,6 +275,9 @@ public class WorkOrderServiceImpl implements WorkOrderService {
 		MP0025_SyncWorkOrder_001 syncWO = new MP0025_SyncWorkOrder_001();
 		syncWO.setWorkOrder(inforWorkOrder);
 
+		if(workorderParam.isConfirmedIncompleteChecklist())
+			syncWO.setConfirmincompletechecklist("confirmed");
+
 		if (context.getCredentials() != null) {
 			inforws.syncWorkOrderOp(syncWO, tools.getOrganizationCode(context),
 					tools.createSecurityHeader(context), "TERMINATE", null,


### PR DESCRIPTION
**Please merge https://github.com/cern-eam/eam-wshub-core/pull/14 first.**

See the corresponding PR on https://github.com/cern-eam/eam-components/pull/22.

Improves the usability of work orders with thousands of checklists.

The main changes that have been done is collapsing the activities and equipments and filtering of checklists by activity/equipment. The first one ensures that not all checklists are shown at the same time, which mainly reduces the time and system requirements of loading the largest work orders. The filtering allows users to directly specify the activity and equipment they are interested in, and see the corresponding checklists.

These two filters work in tandem: if an activity filter is selected, only the equipments for that activity are shown in the equipment filter.

Lastly, when the "Hide Follow-up" checkbox in the checklist task plan definition (in Infor EAM) is checked, this is propagated to EAM Light and this option is not shown.
