### PR TITLE
Integration Testing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,12 +84,6 @@
 			<version>2.2</version>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.12</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>ch.cern.eam</groupId>
 			<artifactId>eam-wshub-proxyclient</artifactId>
 			<version>11.4-9</version>
@@ -98,6 +92,31 @@
 			<groupId>commons-beanutils</groupId>
 			<artifactId>commons-beanutils</artifactId>
 			<version>1.9.4</version>
+		</dependency>
+		<!-- test dependencies -->
+		<dependency>
+			<groupId>org.apache.cxf</groupId>
+			<artifactId>cxf-rt-frontend-jaxws</artifactId>
+			<version>3.3.5</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.cxf</groupId>
+			<artifactId>cxf-rt-transports-http</artifactId>
+			<version>3.3.5</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<version>5.6.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<version>5.6.0</version>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 
@@ -153,6 +172,11 @@
 				</configuration>
 			</plugin>
 
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>2.22.2</version>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -177,6 +177,26 @@
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>2.22.2</version>
 			</plugin>
+
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>0.8.5</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>report</id>
+						<phase>prepare-package</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -176,6 +176,9 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>2.22.2</version>
+				<configuration>
+					<useFile>false</useFile>
+				</configuration>
 			</plugin>
 
 			<plugin>

--- a/src/test/java/ch/cern/eam/wshub/core/GlobalContext.java
+++ b/src/test/java/ch/cern/eam/wshub/core/GlobalContext.java
@@ -29,7 +29,7 @@ public class GlobalContext {
                 .withLogger(Logger.getLogger("wshublogger"))
                 .build();
 
-        context = new InforContext(new Credentials("plavarin", "***REMOVED***"));
+        context = new InforContext(new Credentials(System.getenv("TESTS_USERNAME"), System.getenv("TESTS_PASSPHRASE")));
         username = context.getCredentials().getUsername().toUpperCase();
 
         tools = inforClient.getTools();

--- a/src/test/java/ch/cern/eam/wshub/core/GlobalContext.java
+++ b/src/test/java/ch/cern/eam/wshub/core/GlobalContext.java
@@ -22,6 +22,9 @@ public class GlobalContext {
     public static LocationService locationService;
     public static EquipmentFacadeService equipmentFacadeService;
 
+    final private static String RANDOM_CHAR_SET =
+        "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
     static {
         inforClient = new InforClient.Builder("https://cmmsx-test.cern.ch/axis/services/EWSConnector")
                 .withDefaultTenant("infor")
@@ -40,7 +43,22 @@ public class GlobalContext {
         equipmentFacadeService = inforClient.getEquipmentFacadeService();
     }
 
+    public static String getRandomCharacter() {
+        int index = random.nextInt(RANDOM_CHAR_SET.length());
+        return RANDOM_CHAR_SET.substring(index, index + 1);
+    }
+
+    public static String getRandomString(int length) {
+        if(length > 100)
+            throw new IllegalArgumentException("This function has low performance on large strings");
+
+        String returnString = "";
+        for(int i = 0; i < length; ++i)
+            returnString += getRandomCharacter();
+        return returnString;
+    }
+
     public static String getCode(String type) {
-        return "7LO7WD" + type + username + "-" + random.nextInt(Integer.MAX_VALUE);
+        return "7LO7WD" + type + username + "-" + getRandomString(10);
     }
 }

--- a/src/test/java/ch/cern/eam/wshub/core/GlobalContext.java
+++ b/src/test/java/ch/cern/eam/wshub/core/GlobalContext.java
@@ -3,6 +3,8 @@ package ch.cern.eam.wshub.core;
 import ch.cern.eam.wshub.core.client.InforClient;
 import ch.cern.eam.wshub.core.client.InforContext;
 import ch.cern.eam.wshub.core.services.entities.Credentials;
+import ch.cern.eam.wshub.core.services.equipment.EquipmentFacadeService;
+import ch.cern.eam.wshub.core.services.equipment.LocationService;
 import ch.cern.eam.wshub.core.tools.Tools;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -17,6 +19,9 @@ public class GlobalContext {
     public static String username;
     public static Random random;
 
+    public static LocationService locationService;
+    public static EquipmentFacadeService equipmentFacadeService;
+
     static {
         inforClient = new InforClient.Builder("https://cmmsx-test.cern.ch/axis/services/EWSConnector")
                 .withDefaultTenant("infor")
@@ -30,6 +35,9 @@ public class GlobalContext {
         tools = inforClient.getTools();
 
         random = new Random();
+
+        locationService = inforClient.getLocationService();
+        equipmentFacadeService = inforClient.getEquipmentFacadeService();
     }
 
     public static String getCode(String type) {

--- a/src/test/java/ch/cern/eam/wshub/core/GlobalContext.java
+++ b/src/test/java/ch/cern/eam/wshub/core/GlobalContext.java
@@ -70,12 +70,12 @@ public class GlobalContext {
     }
 
     private static String getRandomString(int length) {
-        if(length > 100)
+        if(length > 100) {
             throw new IllegalArgumentException("This function has low performance on large strings");
+        }
 
         String returnString = "";
-        for(int i = 0; i < length; ++i)
-            returnString += getRandomCharacter();
+        for(int i = 0; i < length; ++i) returnString += getRandomCharacter();
         return returnString;
     }
 }

--- a/src/test/java/ch/cern/eam/wshub/core/GlobalContext.java
+++ b/src/test/java/ch/cern/eam/wshub/core/GlobalContext.java
@@ -20,9 +20,6 @@ public class GlobalContext {
     public static String username;
     public static Random random;
 
-    public static LocationService locationService;
-    public static EquipmentFacadeService equipmentFacadeService;
-
     public static Date getCurrentDate() {
         Calendar calendar = Calendar.getInstance();
         calendar.setTime(new Date());
@@ -57,25 +54,17 @@ public class GlobalContext {
         tools = inforClient.getTools();
 
         random = new Random();
-
-        locationService = inforClient.getLocationService();
-        equipmentFacadeService = inforClient.getEquipmentFacadeService();
     }
 
     final private static String RANDOM_CHAR_SET =
             "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-    private static String getRandomCharacter() {
-        int index = random.nextInt(RANDOM_CHAR_SET.length());
-        return RANDOM_CHAR_SET.substring(index, index + 1);
+    private static char getRandomCharacter() {
+        return RANDOM_CHAR_SET.charAt(random.nextInt(RANDOM_CHAR_SET.length()));
     }
 
     private static String getRandomString(int length) {
-        if(length > 100) {
-            throw new IllegalArgumentException("This function has low performance on large strings");
-        }
-
-        String returnString = "";
-        for(int i = 0; i < length; ++i) returnString += getRandomCharacter();
-        return returnString;
+        char[] charArr = new char[length];
+        for(int i = 0; i < length; ++i) charArr[i] = getRandomCharacter();
+        return new String(charArr);
     }
 }

--- a/src/test/java/ch/cern/eam/wshub/core/GlobalContext.java
+++ b/src/test/java/ch/cern/eam/wshub/core/GlobalContext.java
@@ -3,8 +3,6 @@ package ch.cern.eam.wshub.core;
 import ch.cern.eam.wshub.core.client.InforClient;
 import ch.cern.eam.wshub.core.client.InforContext;
 import ch.cern.eam.wshub.core.services.entities.Credentials;
-import ch.cern.eam.wshub.core.services.equipment.EquipmentFacadeService;
-import ch.cern.eam.wshub.core.services.equipment.LocationService;
 import ch.cern.eam.wshub.core.tools.Tools;
 
 import java.util.Calendar;
@@ -36,6 +34,10 @@ public class GlobalContext {
     public static String getCode(TypeCode type) {
         return "__T3ST__" + type.name() + "-" + getRandomString(16);
     }
+
+    public static String DEPARTMENT = "HXMF";
+    public static String COST_CODE = "H#96231";
+    public static String ASSET_CODE = "PA-A-001";
 
     static {
         int cores = Runtime.getRuntime().availableProcessors();

--- a/src/test/java/ch/cern/eam/wshub/core/GlobalContext.java
+++ b/src/test/java/ch/cern/eam/wshub/core/GlobalContext.java
@@ -1,0 +1,38 @@
+package ch.cern.eam.wshub.core;
+
+import ch.cern.eam.wshub.core.client.InforClient;
+import ch.cern.eam.wshub.core.client.InforContext;
+import ch.cern.eam.wshub.core.services.entities.Credentials;
+import ch.cern.eam.wshub.core.tools.Tools;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.util.Random;
+import java.util.logging.Logger;
+
+public class GlobalContext {
+    public static InforClient inforClient;
+    public static InforContext context;
+    public static Tools tools;
+    public static String username;
+    public static Random random;
+
+    static {
+        inforClient = new InforClient.Builder("https://cmmsx-test.cern.ch/axis/services/EWSConnector")
+                .withDefaultTenant("infor")
+                .withDefaultOrganizationCode("*")
+                .withLogger(Logger.getLogger("wshublogger"))
+                .build();
+
+        context = new InforContext(new Credentials("plavarin", "***REMOVED***"));
+        username = context.getCredentials().getUsername().toUpperCase();
+
+        tools = inforClient.getTools();
+
+        random = new Random();
+    }
+
+    public static String getCode(String type) {
+        return "7LO7WD" + type + username + "-" + random.nextInt(Integer.MAX_VALUE);
+    }
+}

--- a/src/test/java/ch/cern/eam/wshub/core/GlobalContext.java
+++ b/src/test/java/ch/cern/eam/wshub/core/GlobalContext.java
@@ -6,13 +6,17 @@ import ch.cern.eam.wshub.core.services.entities.Credentials;
 import ch.cern.eam.wshub.core.services.equipment.EquipmentFacadeService;
 import ch.cern.eam.wshub.core.services.equipment.LocationService;
 import ch.cern.eam.wshub.core.tools.Tools;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
-import org.junit.jupiter.api.extension.ExtensionContext;
 
+import java.util.Calendar;
+import java.util.Date;
 import java.util.Random;
 import java.util.logging.Logger;
 
 public class GlobalContext {
+    public enum TypeCode {
+        L
+    }
+
     public static InforClient inforClient;
     public static InforContext context;
     public static Tools tools;
@@ -43,12 +47,26 @@ public class GlobalContext {
         equipmentFacadeService = inforClient.getEquipmentFacadeService();
     }
 
-    public static String getRandomCharacter() {
+    public static Date getCurrentDate() {
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTime(new Date());
+        calendar.set(Calendar.HOUR_OF_DAY, 0);
+        calendar.set(Calendar.MINUTE, 0);
+        calendar.set(Calendar.SECOND, 0);
+        calendar.set(Calendar.MILLISECOND, 0);
+        return calendar.getTime();
+    }
+
+    public static String getCode(TypeCode type) {
+        return "__T3ST__" + type.name() + "-" + getRandomString(16);
+    }
+
+    private static String getRandomCharacter() {
         int index = random.nextInt(RANDOM_CHAR_SET.length());
         return RANDOM_CHAR_SET.substring(index, index + 1);
     }
 
-    public static String getRandomString(int length) {
+    private static String getRandomString(int length) {
         if(length > 100)
             throw new IllegalArgumentException("This function has low performance on large strings");
 
@@ -56,9 +74,5 @@ public class GlobalContext {
         for(int i = 0; i < length; ++i)
             returnString += getRandomCharacter();
         return returnString;
-    }
-
-    public static String getCode(String type) {
-        return "7LO7WD" + type + username + "-" + getRandomString(10);
     }
 }

--- a/src/test/java/ch/cern/eam/wshub/core/GlobalContext.java
+++ b/src/test/java/ch/cern/eam/wshub/core/GlobalContext.java
@@ -10,13 +10,10 @@ import ch.cern.eam.wshub.core.tools.Tools;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Random;
+import java.util.concurrent.Executors;
 import java.util.logging.Logger;
 
 public class GlobalContext {
-    public enum TypeCode {
-        L
-    }
-
     public static InforClient inforClient;
     public static InforContext context;
     public static Tools tools;
@@ -26,14 +23,32 @@ public class GlobalContext {
     public static LocationService locationService;
     public static EquipmentFacadeService equipmentFacadeService;
 
-    final private static String RANDOM_CHAR_SET =
-        "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    public static Date getCurrentDate() {
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTime(new Date());
+        calendar.set(Calendar.HOUR_OF_DAY, 0);
+        calendar.set(Calendar.MINUTE, 0);
+        calendar.set(Calendar.SECOND, 0);
+        calendar.set(Calendar.MILLISECOND, 0);
+        return calendar.getTime();
+    }
+
+    public enum TypeCode {
+        L
+    }
+    public static String getCode(TypeCode type) {
+        return "__T3ST__" + type.name() + "-" + getRandomString(16);
+    }
 
     static {
+        int cores = Runtime.getRuntime().availableProcessors();
+        int threadPoolSize = cores * 2;
+
         inforClient = new InforClient.Builder("https://cmmsx-test.cern.ch/axis/services/EWSConnector")
                 .withDefaultTenant("infor")
                 .withDefaultOrganizationCode("*")
                 .withLogger(Logger.getLogger("wshublogger"))
+                .withExecutorService(Executors.newFixedThreadPool(threadPoolSize))
                 .build();
 
         context = new InforContext(new Credentials(System.getenv("TESTS_USERNAME"), System.getenv("TESTS_PASSPHRASE")));
@@ -47,20 +62,8 @@ public class GlobalContext {
         equipmentFacadeService = inforClient.getEquipmentFacadeService();
     }
 
-    public static Date getCurrentDate() {
-        Calendar calendar = Calendar.getInstance();
-        calendar.setTime(new Date());
-        calendar.set(Calendar.HOUR_OF_DAY, 0);
-        calendar.set(Calendar.MINUTE, 0);
-        calendar.set(Calendar.SECOND, 0);
-        calendar.set(Calendar.MILLISECOND, 0);
-        return calendar.getTime();
-    }
-
-    public static String getCode(TypeCode type) {
-        return "__T3ST__" + type.name() + "-" + getRandomString(16);
-    }
-
+    final private static String RANDOM_CHAR_SET =
+            "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
     private static String getRandomCharacter() {
         int index = random.nextInt(RANDOM_CHAR_SET.length());
         return RANDOM_CHAR_SET.substring(index, index + 1);

--- a/src/test/java/ch/cern/eam/wshub/core/services/equipment/TestEquipmentFacadeService.java
+++ b/src/test/java/ch/cern/eam/wshub/core/services/equipment/TestEquipmentFacadeService.java
@@ -14,7 +14,7 @@ import static ch.cern.eam.wshub.core.GlobalContext.*;
 public class TestEquipmentFacadeService {
     @Test
     public void testDeprecatedLocations() throws InforException {
-        String code = getCode("L");
+        String code = getCode(TypeCode.L);
         Location location = new Location();
         location.setCode(code);
         location.setDescription("location test");

--- a/src/test/java/ch/cern/eam/wshub/core/services/equipment/TestEquipmentFacadeService.java
+++ b/src/test/java/ch/cern/eam/wshub/core/services/equipment/TestEquipmentFacadeService.java
@@ -7,6 +7,10 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 import static ch.cern.eam.wshub.core.GlobalContext.*;
 
+/*
+    TEST ASSUMPTIONS:
+        There is a department "HXMF"
+ */
 public class TestEquipmentFacadeService {
     @Test
     public void testDeprecatedLocations() throws InforException {

--- a/src/test/java/ch/cern/eam/wshub/core/services/equipment/TestEquipmentFacadeService.java
+++ b/src/test/java/ch/cern/eam/wshub/core/services/equipment/TestEquipmentFacadeService.java
@@ -2,6 +2,7 @@ package ch.cern.eam.wshub.core.services.equipment;
 
 import ch.cern.eam.wshub.core.services.equipment.entities.Location;
 import ch.cern.eam.wshub.core.tools.InforException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -12,6 +13,15 @@ import static ch.cern.eam.wshub.core.GlobalContext.*;
         There is a department "HXMF"
  */
 public class TestEquipmentFacadeService {
+    private LocationService locationService;
+    private EquipmentFacadeService equipmentFacadeService;
+
+    @BeforeEach
+    void setup() throws Exception {
+        locationService = inforClient.getLocationService();
+        equipmentFacadeService = inforClient.getEquipmentFacadeService();
+    }
+
     @Test
     public void testDeprecatedLocations() throws InforException {
         String code = getCode(TypeCode.L);

--- a/src/test/java/ch/cern/eam/wshub/core/services/equipment/TestEquipmentFacadeService.java
+++ b/src/test/java/ch/cern/eam/wshub/core/services/equipment/TestEquipmentFacadeService.java
@@ -1,0 +1,23 @@
+package ch.cern.eam.wshub.core.services.equipment;
+
+import ch.cern.eam.wshub.core.services.equipment.entities.Location;
+import ch.cern.eam.wshub.core.tools.InforException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static ch.cern.eam.wshub.core.GlobalContext.*;
+
+public class TestEquipmentFacadeService {
+    @Test
+    public void testDeprecatedLocations() throws InforException {
+        String code = getCode("L");
+        Location location = new Location();
+        location.setCode(code);
+        location.setDescription("location test");
+        location.setDepartmentCode("HXMF");
+        locationService.createLocation(context, location);
+
+        assertThrows(InforException.class, () -> equipmentFacadeService.readEquipment(context, code));
+        assertThrows(InforException.class, () -> equipmentFacadeService.deleteEquipment(context, code));
+    }
+}

--- a/src/test/java/ch/cern/eam/wshub/core/services/equipment/TestEquipmentFacadeService.java
+++ b/src/test/java/ch/cern/eam/wshub/core/services/equipment/TestEquipmentFacadeService.java
@@ -10,7 +10,7 @@ import static ch.cern.eam.wshub.core.GlobalContext.*;
 
 /*
     TEST ASSUMPTIONS:
-        There is a department "HXMF"
+        None
  */
 public class TestEquipmentFacadeService {
     private LocationService locationService;
@@ -28,7 +28,7 @@ public class TestEquipmentFacadeService {
         Location location = new Location();
         location.setCode(code);
         location.setDescription("location test");
-        location.setDepartmentCode("HXMF");
+        location.setDepartmentCode(DEPARTMENT);
         locationService.createLocation(context, location);
 
         assertThrows(InforException.class, () -> equipmentFacadeService.readEquipment(context, code));

--- a/src/test/java/ch/cern/eam/wshub/core/services/equipment/TestLocation.java
+++ b/src/test/java/ch/cern/eam/wshub/core/services/equipment/TestLocation.java
@@ -21,8 +21,10 @@ import static ch.cern.eam.wshub.core.GlobalContext.*;
         There is a cost code "H#96231"
         There is a custom field "HMLPR019" on classes "DES" and "FIC"
         There is a custom field "HMLPR147" on class "*"
-        The current date is compatible with the date type in Infor EAM
+        The intervals for the dates must be compatible with Infor EAM
  */
+
+// test the CRUD operations on locations
 public class TestLocation {
     private Location parentLocation;
 
@@ -31,8 +33,11 @@ public class TestLocation {
         parentLocation = createLocation(false);
     }
 
+    // this helper function creates a test location
+    // it also confirms that the created location is read as created
+    // filled: whether the optional fields should be filled
     Location createLocation(boolean filled) throws Exception {
-        String code = getCode("L");
+        String code = getCode(TypeCode.L);
 
         // create the location
         Location location = new Location();
@@ -41,13 +46,7 @@ public class TestLocation {
         location.setDescription("location test");
         location.setDepartmentCode("HXMF");
 
-        Calendar calendar = Calendar.getInstance();
-        calendar.setTime(new Date());
-        calendar.set(Calendar.HOUR_OF_DAY, 0);
-        calendar.set(Calendar.MINUTE, 0);
-        calendar.set(Calendar.SECOND, 0);
-        calendar.set(Calendar.MILLISECOND, 0);
-        Date date = calendar.getTime();
+        Date date = getCurrentDate();
 
         if(filled) {
             location.setClassCode("DES");
@@ -110,6 +109,7 @@ public class TestLocation {
         return location;
     }
 
+    // tests creation of a unfilled location, and fills it using an update
     @Test
     void testCreateNullUpdateFill() throws Exception {
         Location location = createLocation(false);
@@ -211,6 +211,7 @@ public class TestLocation {
         assertEquals("10", generalCustomField.getValue());
     }
 
+    // tests creation of a filled location, and nulls it using an update
     @Test
     void testCreateFillUpdateNull() throws Exception {
         Location location = createLocation(true);
@@ -261,6 +262,7 @@ public class TestLocation {
         assertEquals("10", generalCustomField.getValue());
     }
 
+    // tests the deletion of locations
     @Test
     void testDelete() throws Exception {
         Location location = createLocation(false);
@@ -276,6 +278,8 @@ public class TestLocation {
         }
     }
 
+    // tests whether default values for the location fields have been set
+    // (which would be a big problem when updating just part of a location)
     @Test
     void testDefaultValues() throws Exception {
         Location location = createLocation(true);
@@ -290,6 +294,8 @@ public class TestLocation {
         assertEquals(true, location.getOutOfService());
     }
 
+    // tests changing a filled location from class DES to class FIC
+    // ensuring the custom fields are kept
     @Test
     void testMergeFromFilled() throws Exception {
         String code = createLocation(true).getCode();
@@ -309,6 +315,8 @@ public class TestLocation {
         assertEquals("10", generalCustomField.getValue());
     }
 
+    // tests changing a unfilled location from no class to FIC
+    // ensuring the nullified values are kept
     @Test
     void testMergeFromEmpty() throws Exception {
         String code = createLocation(false).getCode();

--- a/src/test/java/ch/cern/eam/wshub/core/services/equipment/TestLocation.java
+++ b/src/test/java/ch/cern/eam/wshub/core/services/equipment/TestLocation.java
@@ -14,6 +14,15 @@ import java.util.Date;
 import static org.junit.jupiter.api.Assertions.*;
 import static ch.cern.eam.wshub.core.GlobalContext.*;
 
+/*
+    TEST ASSUMPTIONS:
+        There is a department "HXMF"
+        There are location classes "DES" and "FIC"
+        There is a cost code "H#96231"
+        There is a custom field "HMLPR019" on classes "DES" and "FIC"
+        There is a custom field "HMLPR147" on class "*"
+        The current date is compatible with the date type in Infor EAM
+ */
 public class TestLocation {
     private Location parentLocation;
 

--- a/src/test/java/ch/cern/eam/wshub/core/services/equipment/TestLocation.java
+++ b/src/test/java/ch/cern/eam/wshub/core/services/equipment/TestLocation.java
@@ -14,8 +14,6 @@ import static org.junit.jupiter.api.Assertions.*;
 import static ch.cern.eam.wshub.core.GlobalContext.*;
 
 public class TestLocation {
-    private LocationService locationService = inforClient.getLocationService();
-
     private Location parentLocation;
 
     @BeforeEach

--- a/src/test/java/ch/cern/eam/wshub/core/services/equipment/TestLocation.java
+++ b/src/test/java/ch/cern/eam/wshub/core/services/equipment/TestLocation.java
@@ -26,9 +26,11 @@ import static ch.cern.eam.wshub.core.GlobalContext.*;
 // test the CRUD operations on locations
 public class TestLocation {
     private Location parentLocation;
+    private LocationService locationService;
 
     @BeforeEach
     void setup() throws Exception {
+        locationService = inforClient.getLocationService();
         parentLocation = createLocation(false);
     }
 

--- a/src/test/java/ch/cern/eam/wshub/core/services/equipment/TestLocation.java
+++ b/src/test/java/ch/cern/eam/wshub/core/services/equipment/TestLocation.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
-import java.util.Calendar;
 import java.util.Date;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -155,13 +154,7 @@ public class TestLocation {
         udf.setUdfchar01("test");
         udf.setUdfchkbox01(true);
 
-        Calendar calendar = Calendar.getInstance();
-        calendar.setTime(new Date());
-        calendar.set(Calendar.HOUR_OF_DAY, 0);
-        calendar.set(Calendar.MINUTE, 0);
-        calendar.set(Calendar.SECOND, 0);
-        calendar.set(Calendar.MILLISECOND, 0);
-        Date date = calendar.getTime();
+        Date date = getCurrentDate();
 
         udf.setUdfdate01(date);
 

--- a/src/test/java/ch/cern/eam/wshub/core/services/equipment/TestLocation.java
+++ b/src/test/java/ch/cern/eam/wshub/core/services/equipment/TestLocation.java
@@ -1,25 +1,36 @@
 package ch.cern.eam.wshub.core.services.equipment;
 
+import ch.cern.eam.wshub.core.services.entities.CustomField;
+import ch.cern.eam.wshub.core.services.entities.UserDefinedFields;
 import ch.cern.eam.wshub.core.services.equipment.entities.Location;
 import ch.cern.eam.wshub.core.tools.InforException;
 import org.junit.jupiter.api.Test;
+
+import java.util.Calendar;
+import java.util.Date;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static ch.cern.eam.wshub.core.GlobalContext.*;
 
 public class TestLocation {
-    @Test
-    void testCreateUpdate() throws Exception {
+    private static LocationService locationService = inforClient.getLocationService();
+    Location createLocation() throws Exception {
         String code = getCode("L");
-
-        LocationService locationService = inforClient.getLocationService();
 
         // create the location
         Location location = new Location();
+        // set mandatory fields
         location.setCode(code);
         location.setDescription("location test");
         location.setDepartmentCode("HXMF");
         locationService.createLocation(context, location);
+        return location;
+    }
+
+    @Test
+    void testCreateUpdate() throws Exception {
+        Location location = createLocation();
+        String code = location.getCode();
 
         // confirm it has been created with the correct fields
         location = locationService.readLocation(context, code);
@@ -27,29 +38,97 @@ public class TestLocation {
         assertEquals("location test", location.getDescription());
         assertEquals("HXMF", location.getDepartmentCode());
 
+        // check that all the other fields are null
+        assertEquals(null, location.getClassCode());
+        assertEquals(false, location.getSafety());
+        assertEquals(false, location.getOutOfService());
+        assertEquals(null, location.getCostCode());
+        assertEquals(null, location.getUserDefinedFields().getUdfchar01());
+        assertEquals(false, location.getUserDefinedFields().getUdfchkbox01());
+        assertEquals(null, location.getUserDefinedFields().getUdfdate01());
+        assertEquals(0, location.getCustomFields().length);
+
         // update the just read location
         location.setDescription("update test");
         location.setDepartmentCode("FC08");
+
+        // set other fields to non-null values
+        location.setClassCode("DES");
+        location.setSafety(true);
+        location.setOutOfService(true);
+        location.setCostCode("H#96231");
+
+        UserDefinedFields udf = location.getUserDefinedFields();
+        udf.setUdfchar01("test");
+        udf.setUdfchkbox01(true);
+
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTime(new Date());
+        calendar.set(Calendar.HOUR_OF_DAY, 0);
+        calendar.set(Calendar.MINUTE, 0);
+        calendar.set(Calendar.SECOND, 0);
+        calendar.set(Calendar.MILLISECOND, 0);
+        Date date = calendar.getTime();
+
+        udf.setUdfdate01(date);
+
+        locationService.updateLocation(context, location);
+
+        CustomField[] customFields = new CustomField[1];
+        customFields[0] = new CustomField();
+        customFields[0].setCode("HMLPR019");
+        customFields[0].setValue("5");
+
+        location.setCustomFields(customFields);
+
         locationService.updateLocation(context, location);
 
         // read the location back again and confirm it has been updated
         location = locationService.readLocation(context, code);
         assertEquals("update test", location.getDescription());
         assertEquals("FC08", location.getDepartmentCode());
+
+        assertEquals("DES", location.getClassCode());
+        assertEquals(true, location.getSafety());
+        assertEquals(true, location.getOutOfService());
+        assertEquals("H#96231", location.getCostCode());
+        assertEquals("test", location.getUserDefinedFields().getUdfchar01());
+        assertEquals(true, location.getUserDefinedFields().getUdfchkbox01());
+        assertEquals(date, location.getUserDefinedFields().getUdfdate01());
+        assertEquals(1, location.getCustomFields().length);
+        assertEquals("HMLPR019", location.getCustomFields()[0].getCode());
+        assertEquals("5", location.getCustomFields()[0].getValue());
+
+        // null all values
+        location.setClassCode("");
+        location.setSafety(false);
+        location.setOutOfService(false);
+        location.setCostCode("");
+
+        udf = location.getUserDefinedFields();
+        udf.setUdfchar01("");
+        udf.setUdfchkbox01(false);
+        udf.setUdfdate01(new Date(0));
+
+        location.setCustomFields(new CustomField[0]);
+
+        locationService.updateLocation(context, location);
+
+        location = locationService.readLocation(context, code);
+        assertEquals(null, location.getClassCode());
+        assertEquals(false, location.getSafety());
+        assertEquals(false, location.getOutOfService());
+        assertEquals(null, location.getCostCode());
+        assertEquals(null, location.getUserDefinedFields().getUdfchar01());
+        assertEquals(false, location.getUserDefinedFields().getUdfchkbox01());
+        assertEquals(null, location.getUserDefinedFields().getUdfdate01());
+        assertEquals(0, location.getCustomFields().length);
     }
 
     @Test
     void testDelete() throws Exception {
-        String code = getCode("L");
-
-        LocationService locationService = inforClient.getLocationService();
-
-        // create the location
-        Location location = new Location();
-        location.setCode(code);
-        location.setDescription("location test");
-        location.setDepartmentCode("HXMF");
-        locationService.createLocation(context, location);
+        Location location = createLocation();
+        String code = location.getCode();
 
         locationService.deleteLocation(context, code);
         // read the location to confirm it has been deleted

--- a/src/test/java/ch/cern/eam/wshub/core/services/equipment/TestLocation.java
+++ b/src/test/java/ch/cern/eam/wshub/core/services/equipment/TestLocation.java
@@ -15,9 +15,7 @@ import static ch.cern.eam.wshub.core.GlobalContext.*;
 
 /*
     TEST ASSUMPTIONS:
-        There is a department "HXMF"
         There are location classes "DES" and "FIC"
-        There is a cost code "H#96231"
         There is a custom field "HMLPR019" on classes "DES" and "FIC"
         There is a custom field "HMLPR147" on class "*"
         The intervals for the dates must be compatible with Infor EAM
@@ -45,7 +43,7 @@ public class TestLocation {
         // set mandatory fields
         location.setCode(code);
         location.setDescription("location test");
-        location.setDepartmentCode("HXMF");
+        location.setDepartmentCode(DEPARTMENT);
 
         Date date = getCurrentDate();
 
@@ -53,7 +51,7 @@ public class TestLocation {
             location.setClassCode("DES");
             location.setSafety(true);
             location.setOutOfService(true);
-            location.setCostCode("H#96231");
+            location.setCostCode(COST_CODE);
             location.setHierarchyLocationCode(parentLocation.getCode());
 
             UserDefinedFields udf = new UserDefinedFields();
@@ -81,16 +79,16 @@ public class TestLocation {
         location = locationService.readLocation(context, code);
         assertEquals(code, location.getCode());
         assertEquals("location test", location.getDescription());
-        assertEquals("HXMF", location.getDepartmentCode());
+        assertEquals(DEPARTMENT, location.getDepartmentCode());
 
         if(filled) {
             assertEquals("location test", location.getDescription());
-            assertEquals("HXMF", location.getDepartmentCode());
+            assertEquals(DEPARTMENT, location.getDepartmentCode());
 
             assertEquals("DES", location.getClassCode());
             assertEquals(true, location.getSafety());
             assertEquals(true, location.getOutOfService());
-            assertEquals("H#96231", location.getCostCode());
+            assertEquals(COST_CODE, location.getCostCode());
             assertEquals(parentLocation.getCode(), location.getHierarchyLocationCode());
             assertEquals("test", location.getUserDefinedFields().getUdfchar01());
             assertEquals(true, location.getUserDefinedFields().getUdfchkbox01());
@@ -120,7 +118,7 @@ public class TestLocation {
         location = locationService.readLocation(context, code);
         assertEquals(code, location.getCode());
         assertEquals("location test", location.getDescription());
-        assertEquals("HXMF", location.getDepartmentCode());
+        assertEquals(DEPARTMENT, location.getDepartmentCode());
 
         // check that all the other fields are null
         assertEquals(null, location.getClassCode());
@@ -149,7 +147,7 @@ public class TestLocation {
         location.setClassCode("DES");
         location.setSafety(true);
         location.setOutOfService(true);
-        location.setCostCode("H#96231");
+        location.setCostCode(COST_CODE);
         location.setHierarchyLocationCode(parentLocation.getCode());
 
         UserDefinedFields udf = location.getUserDefinedFields();
@@ -189,7 +187,7 @@ public class TestLocation {
         assertEquals("DES", location.getClassCode());
         assertEquals(true, location.getSafety());
         assertEquals(true, location.getOutOfService());
-        assertEquals("H#96231", location.getCostCode());
+        assertEquals(COST_CODE, location.getCostCode());
         assertEquals(parentLocation.getCode(), location.getHierarchyLocationCode());
         assertEquals("test", location.getUserDefinedFields().getUdfchar01());
         assertEquals(true, location.getUserDefinedFields().getUdfchkbox01());

--- a/src/test/java/ch/cern/eam/wshub/core/services/equipment/TestLocation.java
+++ b/src/test/java/ch/cern/eam/wshub/core/services/equipment/TestLocation.java
@@ -139,8 +139,6 @@ public class TestLocation {
 
         udf.setUdfdate01(date);
 
-        locationService.updateLocation(context, location);
-
         CustomField[] customFields = new CustomField[1];
         customFields[0] = new CustomField();
         customFields[0].setCode("HMLPR019");
@@ -148,6 +146,10 @@ public class TestLocation {
 
         location.setCustomFields(customFields);
 
+        locationService.updateLocation(context, location);
+
+        // try to update the location with the same values again,
+        // ensuring we can update a filled location to a filled location
         locationService.updateLocation(context, location);
 
         // read the location back again and confirm it has been updated
@@ -189,6 +191,10 @@ public class TestLocation {
 
         locationService.updateLocation(context, location);
 
+        // try to update the location with the same values again,
+        // ensuring we can update a nullified location to a nullified location
+        locationService.updateLocation(context, location);
+
         location = locationService.readLocation(context, code);
         assertEquals(null, location.getClassCode());
         assertEquals(false, location.getSafety());
@@ -214,5 +220,19 @@ public class TestLocation {
         } catch(InforException e) {
             assertEquals("Cannot find the location record.", e.getMessage());
         }
+    }
+
+    @Test
+    void testDefaultValues() throws Exception {
+        Location location = createLocation(true);
+
+        Location brandNew = new Location();
+        brandNew.setCode(location.getCode());
+        brandNew.setDescription("ricardoricardo");
+        locationService.updateLocation(context, brandNew);
+
+        location = locationService.readLocation(context, location.getCode());
+        assertEquals("ricardoricardo", location.getDescription());
+        assertEquals(true, location.getOutOfService());
     }
 }

--- a/src/test/java/ch/cern/eam/wshub/core/services/equipment/TestLocation.java
+++ b/src/test/java/ch/cern/eam/wshub/core/services/equipment/TestLocation.java
@@ -1,0 +1,63 @@
+package ch.cern.eam.wshub.core.services.equipment;
+
+import ch.cern.eam.wshub.core.services.equipment.entities.Location;
+import ch.cern.eam.wshub.core.tools.InforException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static ch.cern.eam.wshub.core.GlobalContext.*;
+
+public class TestLocation {
+    @Test
+    void testCreateUpdate() throws Exception {
+        String code = getCode("L");
+
+        LocationService locationService = inforClient.getLocationService();
+
+        // create the location
+        Location location = new Location();
+        location.setCode(code);
+        location.setDescription("location test");
+        location.setDepartmentCode("HXMF");
+        locationService.createLocation(context, location);
+
+        // confirm it has been created with the correct fields
+        location = locationService.readLocation(context, code);
+        assertEquals(code, location.getCode());
+        assertEquals("location test", location.getDescription());
+        assertEquals("HXMF", location.getDepartmentCode());
+
+        // update the just read location
+        location.setDescription("update test");
+        location.setDepartmentCode("FC08");
+        locationService.updateLocation(context, location);
+
+        // read the location back again and confirm it has been updated
+        location = locationService.readLocation(context, code);
+        assertEquals("update test", location.getDescription());
+        assertEquals("FC08", location.getDepartmentCode());
+    }
+
+    @Test
+    void testDelete() throws Exception {
+        String code = getCode("L");
+
+        LocationService locationService = inforClient.getLocationService();
+
+        // create the location
+        Location location = new Location();
+        location.setCode(code);
+        location.setDescription("location test");
+        location.setDepartmentCode("HXMF");
+        locationService.createLocation(context, location);
+
+        locationService.deleteLocation(context, code);
+        // read the location to confirm it has been deleted
+        try {
+            locationService.readLocation(context, code);
+            assertTrue(false); // successfully reading a location results in failure
+        } catch(InforException e) {
+            assertEquals("Cannot find the location record.", e.getMessage());
+        }
+    }
+}

--- a/src/test/java/ch/cern/eam/wshub/core/services/equipment/TestWorkOrder.java
+++ b/src/test/java/ch/cern/eam/wshub/core/services/equipment/TestWorkOrder.java
@@ -29,6 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class TestWorkOrder {
     private static WorkOrderService workOrderService = inforClient.getWorkOrderService();
 
+    // this helper function creates a test work order
     WorkOrder createWorkOrder() throws Exception {
         WorkOrder workOrder = new WorkOrder();
         workOrder.setDescription("test");
@@ -43,6 +44,7 @@ public class TestWorkOrder {
         return workOrder;
     }
 
+    // tests whether we can create and update a work order
     @Test
     void testCreateUpdate() throws Exception {
         WorkOrder workOrder = createWorkOrder();

--- a/src/test/java/ch/cern/eam/wshub/core/services/equipment/TestWorkOrder.java
+++ b/src/test/java/ch/cern/eam/wshub/core/services/equipment/TestWorkOrder.java
@@ -1,0 +1,59 @@
+package ch.cern.eam.wshub.core.services.equipment;
+
+import ch.cern.eam.wshub.core.services.entities.CustomField;
+import ch.cern.eam.wshub.core.services.entities.UserDefinedFields;
+import ch.cern.eam.wshub.core.services.equipment.entities.Location;
+import ch.cern.eam.wshub.core.services.workorders.WorkOrderService;
+import ch.cern.eam.wshub.core.services.workorders.entities.WorkOrder;
+import ch.cern.eam.wshub.core.tools.InforException;
+import org.junit.jupiter.api.Test;
+
+import java.util.Calendar;
+import java.util.Date;
+
+import static ch.cern.eam.wshub.core.GlobalContext.*;
+import static ch.cern.eam.wshub.core.GlobalContext.context;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestWorkOrder {
+    private static WorkOrderService workOrderService = inforClient.getWorkOrderService();
+
+    WorkOrder createWorkOrder() throws Exception {
+        WorkOrder workOrder = new WorkOrder();
+        workOrder.setDescription("test");
+        workOrder.setEquipmentCode("PA-A-001");
+        workOrder.setTypeCode("EX");
+        workOrder.setDepartmentCode("RPM");
+        workOrder.setStatusCode("R");
+
+        String number = workOrderService.createWorkOrder(context, workOrder);
+        workOrder.setNumber(number);
+
+        return workOrder;
+    }
+
+    @Test
+    void testCreateUpdate() throws Exception {
+        WorkOrder workOrder = createWorkOrder();
+        String number = workOrder.getNumber();
+
+        workOrder = workOrderService.readWorkOrder(context, number);
+        workOrder.setClassCode("RP01");
+
+        CustomField[] customFields = new CustomField[1];
+        customFields[0] = new CustomField();
+        customFields[0].setCode("P214");
+        customFields[0].setValue("22");
+        workOrder.setCustomFields(customFields);
+        workOrderService.updateWorkOrder(context, workOrder);
+
+        workOrder = workOrderService.readWorkOrder(context, number);
+
+        for(CustomField customField : workOrder.getCustomFields()) {
+            if(customField.getCode().equals("P214")) {
+                assertEquals("22", customField.getValue());
+            }
+        }
+    }
+}

--- a/src/test/java/ch/cern/eam/wshub/core/services/equipment/TestWorkOrder.java
+++ b/src/test/java/ch/cern/eam/wshub/core/services/equipment/TestWorkOrder.java
@@ -19,9 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /*
     TEST ASSUMPTIONS:
-        There is an asset "PA-A-001"
         There is a type code "EX"
-        There is a department "RPM"
         There is a status code "R"
         There is a workorder class "RP01"
         There is a custom field "P214" in the "RP01" class
@@ -33,9 +31,9 @@ public class TestWorkOrder {
     WorkOrder createWorkOrder() throws Exception {
         WorkOrder workOrder = new WorkOrder();
         workOrder.setDescription("test");
-        workOrder.setEquipmentCode("PA-A-001");
+        workOrder.setEquipmentCode(ASSET_CODE);
         workOrder.setTypeCode("EX");
-        workOrder.setDepartmentCode("RPM");
+        workOrder.setDepartmentCode(DEPARTMENT);
         workOrder.setStatusCode("R");
 
         String number = workOrderService.createWorkOrder(context, workOrder);

--- a/src/test/java/ch/cern/eam/wshub/core/services/equipment/TestWorkOrder.java
+++ b/src/test/java/ch/cern/eam/wshub/core/services/equipment/TestWorkOrder.java
@@ -8,6 +8,7 @@ import ch.cern.eam.wshub.core.services.workorders.entities.WorkOrder;
 import ch.cern.eam.wshub.core.tools.InforException;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
 
@@ -16,6 +17,15 @@ import static ch.cern.eam.wshub.core.GlobalContext.context;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+/*
+    TEST ASSUMPTIONS:
+        There is an asset "PA-A-001"
+        There is a type code "EX"
+        There is a department "RPM"
+        There is a status code "R"
+        There is a workorder class "RP01"
+        There is a custom field "P214" in the "RP01" class
+ */
 public class TestWorkOrder {
     private static WorkOrderService workOrderService = inforClient.getWorkOrderService();
 
@@ -50,10 +60,8 @@ public class TestWorkOrder {
 
         workOrder = workOrderService.readWorkOrder(context, number);
 
-        for(CustomField customField : workOrder.getCustomFields()) {
-            if(customField.getCode().equals("P214")) {
-                assertEquals("22", customField.getValue());
-            }
-        }
+        CustomField classCustomField = Arrays.stream(workOrder.getCustomFields())
+                .filter(cf -> cf.getCode().equals("P214")).findFirst().get();
+        assertEquals("22", classCustomField.getValue());
     }
 }

--- a/src/test/resources/junit-platform.properties
+++ b/src/test/resources/junit-platform.properties
@@ -1,0 +1,3 @@
+! https://junit.org/junit5/docs/snapshot/user-guide/#writing-tests-parallel-execution
+junit.jupiter.execution.parallel.enabled = true
+junit.jupiter.execution.parallel.mode.default = concurrent


### PR DESCRIPTION
Adds integration testing to the project, with tests mainly for the location service. This should be extended to other services as features/bugfixes are added.

Integration testing will be added under the following conditions:
- The goal is to spend as little additional development time as possible with the tests, they should be representative of the manual tests we currently perform while implementing the features.
- With every change in eam-wshub-core, there should be an accompanying test of the functionality that it implements.
- Every generated object with a code in EAM should have a code that starts with `__T3ST__`, to make it clear that it is being used for integration testing.
- The tests will be in the same project as eam-wshub-core, following Maven conventions.
