### PR TITLE
[EAM-3113] Delete checklist confirmed when activity update

### DIFF
--- a/src/main/java/ch/cern/eam/wshub/core/services/workorders/LaborBookingService.java
+++ b/src/main/java/ch/cern/eam/wshub/core/services/workorders/LaborBookingService.java
@@ -26,6 +26,9 @@ public interface LaborBookingService {
     @Operation(logOperation = INFOR_OPERATION.ACTIVITY_U)
     String updateActivity(InforContext context, Activity activityParam) throws InforException;
 
+    @Operation(logOperation = INFOR_OPERATION.ACTIVITY_U)
+    String updateActivity(InforContext context, Activity activityParam, String confirmDeleteChecklist) throws InforException;
+
     @Operation(logOperation = INFOR_OPERATION.ACTIVITY_D)
     String deleteActivity(InforContext context, Activity activityParam) throws InforException;
 }

--- a/src/main/java/ch/cern/eam/wshub/core/services/workorders/impl/LaborBookingServiceImpl.java
+++ b/src/main/java/ch/cern/eam/wshub/core/services/workorders/impl/LaborBookingServiceImpl.java
@@ -12,7 +12,6 @@ import ch.cern.eam.wshub.core.tools.ApplicationData;
 import ch.cern.eam.wshub.core.tools.GridTools;
 import ch.cern.eam.wshub.core.tools.InforException;
 import ch.cern.eam.wshub.core.tools.Tools;
-import static ch.cern.eam.wshub.core.tools.DataTypeTools.isNotEmpty;
 import net.datastream.schemas.mp_fields.*;
 import net.datastream.schemas.mp_functions.mp0035_001.MP0035_GetActivity_001;
 import net.datastream.schemas.mp_functions.mp0037_001.MP0037_AddActivity_001;
@@ -27,9 +26,12 @@ import net.datastream.schemas.mp_results.mp0042_001.MP0042_AddLaborBooking_001_R
 import net.datastream.wsdls.inforws.InforWebServicesPT;
 
 import java.math.BigDecimal;
-import java.util.*;
+import java.util.Arrays;
+import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+
+import static ch.cern.eam.wshub.core.tools.DataTypeTools.isNotEmpty;
 
 public class LaborBookingServiceImpl implements LaborBookingService {
 
@@ -233,6 +235,7 @@ public class LaborBookingServiceImpl implements LaborBookingService {
 		//
 		MP0038_SyncActivity_001 syncActivity = new MP0038_SyncActivity_001();
 		syncActivity.setActivity(activityInfor);
+		syncActivity.setConfirmadddeletechecklist("confirmed");
 
 		MP0038_SyncActivity_001_Result syncresult =
 			tools.performInforOperation(context, inforws::syncActivityOp, syncActivity);

--- a/src/main/java/ch/cern/eam/wshub/core/services/workorders/impl/LaborBookingServiceImpl.java
+++ b/src/main/java/ch/cern/eam/wshub/core/services/workorders/impl/LaborBookingServiceImpl.java
@@ -204,6 +204,10 @@ public class LaborBookingServiceImpl implements LaborBookingService {
 	}
 
 	public String updateActivity(InforContext context, Activity activityParam) throws InforException {
+		return updateActivity(context, activityParam, null);
+	}
+
+	public String updateActivity(InforContext context, Activity activityParam, String confirmDeleteChecklist) throws InforException {
 		//
 		// READ THE ACTIVITY FIRST
 		//
@@ -220,7 +224,7 @@ public class LaborBookingServiceImpl implements LaborBookingService {
 		getActivity.getACTIVITYID().getWORKORDERID().setJOBNUM(activityParam.getWorkOrderNumber());
 
 		MP0035_GetActivity_001_Result getresult =
-			tools.performInforOperation(context, inforws::getActivityOp, getActivity);
+				tools.performInforOperation(context, inforws::getActivityOp, getActivity);
 
 		net.datastream.schemas.mp_entities.activity_001.Activity activityInfor = getresult.getResultData().getActivity();
 
@@ -235,10 +239,10 @@ public class LaborBookingServiceImpl implements LaborBookingService {
 		//
 		MP0038_SyncActivity_001 syncActivity = new MP0038_SyncActivity_001();
 		syncActivity.setActivity(activityInfor);
-		syncActivity.setConfirmadddeletechecklist("confirmed");
+		syncActivity.setConfirmadddeletechecklist(confirmDeleteChecklist);
 
 		MP0038_SyncActivity_001_Result syncresult =
-			tools.performInforOperation(context, inforws::syncActivityOp, syncActivity);
+				tools.performInforOperation(context, inforws::syncActivityOp, syncActivity);
 		return syncresult.getResultData().getACTIVITYID().getACTIVITYCODE().getValue() + "";
 	}
 


### PR DESCRIPTION
The attribute `confirmadddeletechecklist` must be set to 'confirmed' in order to correctly detach the task plan from the activity. A dialog could be shown in the frontend representing this confirmation as it happens right now on EAM expanded. 