### PR TITLE
[EAM-3117] Checkbox filters fixed

### DIFF
--- a/src/main/java/ch/cern/eam/wshub/core/services/grids/impl/InforGrids.java
+++ b/src/main/java/ch/cern/eam/wshub/core/services/grids/impl/InforGrids.java
@@ -348,9 +348,16 @@ public class InforGrids implements Serializable {
 					case "LESS_THAN_EQUALS":
 						inforFilter.setOPERATOR("<=");
 						break;
-					case "GREATER_THAN_EQUALS":
-						inforFilter.setOPERATOR(">=");
+					case "SELECTED":
+						inforFilter.setOPERATOR("=");
+						inforFilter.setVALUE("-1");
 						break;
+					case "NOT_SELECTED":
+						inforFilter.setOPERATOR("=");
+						inforFilter.setVALUE("0");
+						break;
+					case "":
+						continue;
 				}
 
 				multiaddon_filters.getMADDON_FILTER().add(inforFilter);

--- a/src/main/java/ch/cern/eam/wshub/core/services/grids/impl/JPAGrids.java
+++ b/src/main/java/ch/cern/eam/wshub/core/services/grids/impl/JPAGrids.java
@@ -2,14 +2,14 @@ package ch.cern.eam.wshub.core.services.grids.impl;
 
 import ch.cern.eam.wshub.core.client.InforContext;
 import ch.cern.eam.wshub.core.services.entities.Credentials;
-import ch.cern.eam.wshub.core.services.grids.entities.*;
-import ch.cern.eam.wshub.core.tools.ApplicationData;
-import ch.cern.eam.wshub.core.tools.InforException;
-import ch.cern.eam.wshub.core.tools.Tools;
 import ch.cern.eam.wshub.core.services.grids.customfields.GridCustomFieldHandler;
+import ch.cern.eam.wshub.core.services.grids.entities.*;
 import ch.cern.eam.wshub.core.services.grids.exceptions.IncorrectParenthesesGridFilterException;
 import ch.cern.eam.wshub.core.services.grids.exceptions.IncorrectSortTypeException;
 import ch.cern.eam.wshub.core.services.grids.exceptions.MissingJoinerGridFilterException;
+import ch.cern.eam.wshub.core.tools.ApplicationData;
+import ch.cern.eam.wshub.core.tools.InforException;
+import ch.cern.eam.wshub.core.tools.Tools;
 import net.datastream.wsdls.inforws.InforWebServicesPT;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -31,6 +31,8 @@ import java.util.*;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import static ch.cern.eam.wshub.core.tools.DataTypeTools.isNotEmpty;
 
 public class JPAGrids implements Serializable {
 
@@ -640,7 +642,7 @@ public class JPAGrids implements Serializable {
 		int filtersLengthMinusOne = filters.size() - 1;
 		for (GridRequestFilter filter : filters) {
 			//skip custom fields
-			if(tagNames.get(filter.getFieldName()) != null){
+			if (tagNames.get(filter.getFieldName()) != null && isNotEmpty(filter.getOperator())) {
 				
 				if (filter.getLeftParenthesis()) filterString.append("(");
 


### PR DESCRIPTION
For non native grid search is checked if the operator is empty, if it is the filter is not added. For native search a conversion has been implemented to use the `SELECTED `and `NOT_SELECTED `operators