### PR TITLE
feat(backend): EAM-6694 attach organisation information to entity key code for equipment reservation comments

### DIFF
--- a/src/main/java/ch/cern/eam/wshub/core/services/comments/impl/CommentServiceImpl.java
+++ b/src/main/java/ch/cern/eam/wshub/core/services/comments/impl/CommentServiceImpl.java
@@ -237,7 +237,7 @@ public class CommentServiceImpl implements CommentService {
 	}
 
 	private static String complementEntityKeyCode(String entityCode, String entityKeyCode, String organization) {
-		if ("OBJ".equals(entityCode) || "PART".equals(entityCode) || "TASK".equals(entityCode)) {
+		if ("OBJ".equals(entityCode) || "PART".equals(entityCode) || "TASK".equals(entityCode) || "CREN".equals(entityCode)) {
 			return entityKeyCode + "#" + organization;
 		}
 		return entityKeyCode;


### PR DESCRIPTION
In order to see in EAM the comments we have created via WShub core to Equipment Reservations, we need to add organisation info to the entity key code.